### PR TITLE
fix: use TransactionPayloadBuilder instead of raw

### DIFF
--- a/src/transactions.ts
+++ b/src/transactions.ts
@@ -13,7 +13,6 @@ import {
 } from '@elrondnetwork/erdjs';
 import BigNumber from "bignumber.js";
 import { smartContract } from './config';
-import { stringToHex } from './utils';
 
 export interface IssueNFTData {
   tokenName: string;


### PR DESCRIPTION
# Description

Use of erdjs ContractCallPayloadBuilder instead raw string payload causing conflict when bytes are not even.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
